### PR TITLE
Use assoc instead of merge

### DIFF
--- a/src/next/jdbc.clj
+++ b/src/next/jdbc.clj
@@ -208,7 +208,7 @@
    (rs/execute! connectable
                 (sql/for-insert table key-map opts)
                 (partial into {})
-                (merge {:return-keys true} opts))))
+                (assoc opts :return-keys true))))
 
 (defn insert-multi!
   "Syntactic sugar over execute! to make inserting columns/rows easier.
@@ -223,7 +223,7 @@
    (rs/execute! connectable
                 (sql/for-insert-multi table cols rows opts)
                 (partial into {})
-                (merge {:return-keys true} opts))))
+                (assoc opts :return-keys true))))
 
 (defn query
   "Syntactic sugar over execute! to provide a query alias.


### PR DESCRIPTION
`merge` is really slow and can be replaced with `assoc` here.

```clj
user=> (cc/quick-bench (merge {} {:return-keys true}))
Evaluation count : 2896926 in 6 samples of 482821 calls.
             Execution time mean : 209,152426 ns
    Execution time std-deviation : 13,675134 ns
   Execution time lower quantile : 196,702057 ns ( 2,5%)
   Execution time upper quantile : 225,120089 ns (97,5%)
                   Overhead used : 8,444260 ns
nil
user=> (cc/quick-bench (assoc {} :return-keys true))
Evaluation count : 24463314 in 6 samples of 4077219 calls.
             Execution time mean : 17,331023 ns
    Execution time std-deviation : 0,470277 ns
   Execution time lower quantile : 16,956913 ns ( 2,5%)
   Execution time upper quantile : 17,930922 ns (97,5%)
                   Overhead used : 8,444260 ns
nil
```