### PR TITLE
Manually destructure options

### DIFF
--- a/src/next/jdbc/transaction.clj
+++ b/src/next/jdbc/transaction.clj
@@ -23,7 +23,9 @@
   as read-only and/or rollback-only (so it will automatically rollback
   instead of committing any changes)."
   [^Connection con f opts]
-  (let [{:keys [isolation read-only rollback-only]} opts
+  (let [isolation (:isolation opts)
+        read-only (:read-only opts)
+        rollback-only (:rollback-only opts)
         old-autocommit (.getAutoCommit con)
         old-isolation  (.getTransactionIsolation con)
         old-readonly   (.isReadOnly con)]


### PR DESCRIPTION
Clojure destucturing is slow, manual destrucutring is fast(er).

```clj
user=> (defn f [{:keys [isolation read-only rollback-only]}] [isolation read-only rollback-only])
#'user/f
user=> (cc/quick-bench (f {}))
Evaluation count : 13689318 in 6 samples of 2281553 calls.
             Execution time mean : 39,601214 ns
    Execution time std-deviation : 2,730398 ns
   Execution time lower quantile : 35,527136 ns ( 2,5%)
   Execution time upper quantile : 42,489642 ns (97,5%)
                   Overhead used : 8,444260 ns

Found 2 outliers in 6 samples (33,3333 %)
	low-severe	 1 (16,6667 %)
	low-mild	 1 (16,6667 %)
 Variance from outliers : 15,1450 % Variance is moderately inflated by outliers
nil
user=> (defn f2 [opts]
          #_=>   (let [isolation (:isolation opts)
          #_=>         read-only (:read-only opts)
          #_=>         rollback-only (:rollback-only opts)]
          #_=>     [isolation read-only rollback-only]))
#'user/f2
user=> (cc/quick-bench (f2 {}))
Evaluation count : 25382820 in 6 samples of 4230470 calls.
             Execution time mean : 17,017467 ns
    Execution time std-deviation : 0,675491 ns
   Execution time lower quantile : 16,161077 ns ( 2,5%)
   Execution time upper quantile : 17,738695 ns (97,5%)
                   Overhead used : 8,444260 ns
nil
```