### PR TITLE
Fixes #60 by adopting a simpler :schema format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The following changes have been committed to the **master** branch since the 1.0
 
 The following changes have been committed to the **issue-60** branch since the 1.0.6 release:
 
-* Address #60 by allowing for additional schema entry formats: `:table/column` is equivalent to the old `[:table :column :one]` and `[:table/column]` is equivalent to the old `[:table :column :many]`. I'm still evaluating what might be needed for #61 before settling on a suitable format for schema extensions.
+* Address #60 by supporting simpler schema entry formats: `:table/column` is equivalent to the old `[:table :column :one]` and `[:table/column]` is equivalent to the old `[:table :column :many]`. The older formats will continue to be supported but should be considered deprecated.
 
 ## Stable Builds
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The following changes have been committed to the **master** branch since the 1.0
 * Added test for using `any(?)` and arrays in PostgreSQL for `IN (?,,,?)` style queries. Added a **Tips & Tricks** section to **Friendly SQL Functions** with database-specific suggestions, that starts with this one.
 * Improved documentation in several areas.
 
+The following changes have been committed to the **issue-60** branch since the 1.0.6 release:
+
+* Address #60 by allowing for additional schema entry formats: `:table/column` is equivalent to the old `[:table :column :one]` and `[:table/column]` is equivalent to the old `[:table :column :many]`. I'm still evaluating what might be needed for #61 before settling on a suitable format for schema extensions.
+
 ## Stable Builds
 
 * 2019-08-24 -- 1.0.6

--- a/test/next/jdbc/result_set_test.clj
+++ b/test/next/jdbc/result_set_test.clj
@@ -30,7 +30,32 @@
         ;; check nav produces a single map with the expected key/value data
         (is (= 1 ((if (postgres?) :fruit/id :FRUIT/ID) object)))
         (is (= "Apple" ((if (postgres?) :fruit/name :FRUIT/NAME) object))))))
-  (testing "custom schema :one"
+  (testing "custom schema *-to-1"
+    (let [connectable (ds)
+          test-row (rs/datafiable-row {:foo/bar 2} connectable
+                                      {:schema {:foo/bar :fruit/id}})
+          data (d/datafy test-row)
+          v (get data :foo/bar)]
+      ;; check datafication is sane
+      (is (= 2 v))
+      (let [object (d/nav data :foo/bar v)]
+        ;; check nav produces a single map with the expected key/value data
+        (is (= 2 ((if (postgres?) :fruit/id :FRUIT/ID) object)))
+        (is (= "Banana" ((if (postgres?) :fruit/name :FRUIT/NAME) object))))))
+  (testing "custom schema *-to-many"
+    (let [connectable (ds)
+          test-row (rs/datafiable-row {:foo/bar 3} connectable
+                                      {:schema {:foo/bar [:fruit/id]}})
+          data (d/datafy test-row)
+          v (get data :foo/bar)]
+      ;; check datafication is sane
+      (is (= 3 v))
+      (let [object (d/nav data :foo/bar v)]
+        ;; check nav produces a result set with the expected key/value data
+        (is (vector? object))
+        (is (= 3 ((if (postgres?) :fruit/id :FRUIT/ID) (first object))))
+        (is (= "Peach" ((if (postgres?) :fruit/name :FRUIT/NAME) (first object)))))))
+  (testing "legacy schema tuples"
     (let [connectable (ds)
           test-row (rs/datafiable-row {:foo/bar 2} connectable
                                       {:schema {:foo/bar [:fruit :id]}})
@@ -41,8 +66,7 @@
       (let [object (d/nav data :foo/bar v)]
         ;; check nav produces a single map with the expected key/value data
         (is (= 2 ((if (postgres?) :fruit/id :FRUIT/ID) object)))
-        (is (= "Banana" ((if (postgres?) :fruit/name :FRUIT/NAME) object))))))
-  (testing "custom schema :many"
+        (is (= "Banana" ((if (postgres?) :fruit/name :FRUIT/NAME) object)))))
     (let [connectable (ds)
           test-row (rs/datafiable-row {:foo/bar 3} connectable
                                       {:schema {:foo/bar [:fruit :id :many]}})


### PR DESCRIPTION
Continues support for old tuple format, which is deprecated (and no longer documented except in the change log!). Adds tests for the new format. Updates documentation to only describe the new format.