### PR TITLE
Add unstrument function to specs

### DIFF
--- a/src/next/jdbc/specs.clj
+++ b/src/next/jdbc/specs.clj
@@ -202,3 +202,23 @@
                   `sql/get-by-id
                   `sql/update!
                   `sql/delete!]))
+
+(defn unstrument []
+  (st/unstrument [`jdbc/get-datasource
+                  `jdbc/get-connection
+                  `jdbc/prepare
+                  `jdbc/plan
+                  `jdbc/execute!
+                  `jdbc/execute-one!
+                  `jdbc/transact
+                  `jdbc/with-transaction
+                  `connection/->pool
+                  `prepare/execute-batch!
+                  `prepare/set-parameters
+                  `sql/insert!
+                  `sql/insert-multi!
+                  `sql/query
+                  `sql/find-by-keys
+                  `sql/get-by-id
+                  `sql/update!
+                  `sql/delete!]))


### PR DESCRIPTION
This PR adds an `unstrument` function to the specs. This makes it handy to instrument/unstrument in a scoped way (rather than writing your own unstrument scoped to next-jdbc or using st/unstrument to unstrument _everything_ at the REPL).

Not sure how important it is, I also signed it off from a Developer Certificate of Origin perspective.

Signed-off-by: Gerred Dillon <hello@gerred.org>