### PR TITLE
Fix next.jdbc.date-time for java.sql.Date

### DIFF
--- a/src/next/jdbc/date_time.clj
+++ b/src/next/jdbc/date_time.clj
@@ -44,4 +44,8 @@
   ;; this is just to help PostgreSQL:
   java.util.Date
   (set-parameter [^java.util.Date v ^PreparedStatement s ^long i]
-    (.setTimestamp s i (Timestamp/from (.toInstant v)))))
+    (.setTimestamp s i (Timestamp/from (.toInstant v))))
+  ;; ... but leave java.*sql*.Date as-is, it doesn't support toInstant
+  java.sql.Date
+  (set-parameter [^java.sql.Date v ^PreparedStatement s ^long i]
+    (.setDate s i v)))


### PR DESCRIPTION
An insert fails with
> UnsupportedOperationException: null at java.sql/java.sql.Date.toInstant(Date.java:316)

if you required `next.jdbc.date-time` added for #73 and the value you are inserting is `java.sql.Date` because it is a subclass of `java.util.Date` and thus gets handled by https://github.com/seancorfield/next-jdbc/blob/master/src/next/jdbc/date_time.clj#L45 - but it doesn't support `toInstant` contrary to its superclass.

The solution is to use `.setDate` with the value as-is instead of `.setTimestamp`.

From https://github.com/openjdk/jdk/blob/master/src/java.sql/share/classes/java/sql/Date.java#L308:
> This method always throws an UnsupportedOperationException and should not be used because SQL {@code Date} values do not have a time component.