### PR TITLE
Switch to new java.data version

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,9 +1,8 @@
 {:paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.10.1"}
-        org.clojure/java.data {:mvn/version "1.0.64"}}
+        org.clojure/java.data {:mvn/version "1.0.73"}}
  :aliases
- {:local {:override-deps {org.clojure/java.data {:local/root "../java.data"}}}
-  :test {:extra-paths ["test"]
+ {:test {:extra-paths ["test"]
          :extra-deps {org.clojure/test.check {:mvn/version "1.0.0"}
                       ;; connection pooling
                       com.zaxxer/HikariCP {:mvn/version "3.4.2"}

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,8 @@
  :deps {org.clojure/clojure {:mvn/version "1.10.1"}
         org.clojure/java.data {:mvn/version "1.0.64"}}
  :aliases
- {:test {:extra-paths ["test"]
+ {:local {:override-deps {org.clojure/java.data {:local/root "../java.data"}}}
+  :test {:extra-paths ["test"]
          :extra-deps {org.clojure/test.check {:mvn/version "1.0.0"}
                       ;; connection pooling
                       com.zaxxer/HikariCP {:mvn/version "3.4.2"}


### PR DESCRIPTION
This allows `bean` to be replaced with `from-java-shallow` and omit known dangerous "getters".