### PR TITLE
Expand datafication; leverage new exception handling in java.data

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.10.1"}
-        org.clojure/java.data {:mvn/version "1.0.73"}}
+        org.clojure/java.data {:mvn/version "1.0.78"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {org.clojure/test.check {:mvn/version "1.0.0"}

--- a/test/next/jdbc/datafy_test.clj
+++ b/test/next/jdbc/datafy_test.clj
@@ -100,7 +100,10 @@
 (comment
   (def con (jdbc/get-connection (ds)))
   (rs/datafiable-result-set (.getTables (.getMetaData con) nil nil nil nil) con {})
-  (def ps (jdbc/prepare con ["SELECT * FROM fruit"]))
+  (def ps (jdbc/prepare con ["SELECT * FROM fruit WHERE grade > ?"]))
+  (require '[next.jdbc.prepare :as prep])
+  (prep/set-parameters ps [30])
   (.execute ps)
   (.getResultSet ps)
+  (.close ps)
   (.close con))


### PR DESCRIPTION
This extends datafication to `ParameterMetadata`, `ResultSet`, and `Statement`, as well as allowing for optional JDBC feature support (by leveraging the more flexible behavior in `clojure.java.data` 1.0.78).