### PR TITLE
Add missing arity to component spec

### DIFF
--- a/src/next/jdbc/specs.clj
+++ b/src/next/jdbc/specs.clj
@@ -150,7 +150,8 @@
 
 (s/fdef connection/component
         :args (s/cat :clazz #(instance? Class %)
-                     :db-spec ::db-spec-or-jdbc))
+                     :db-spec ::db-spec-or-jdbc
+                     :close-fn (s/? ifn?)))
 
 (s/fdef prepare/execute-batch!
         :args (s/cat :ps ::prepared-statement


### PR DESCRIPTION
The close function was missing in the spec for connection/component.

I don't know if there's a way to specify the close-fn args more specifically without hitting generative testing, but if there is I couldn't find it. Seems like it's built in to fspec and doesn't have a clear way to disable.

As a side note, it's also the only spec'ed function not in `fns-with-specs`. I don't know if that was just an oversight or intentional, so I left it as is.
