### PR TITLE
Extend ReadableColumn protocol by adding a 3-arity read-column-by-label that takes a ResultSetMetaData

### DIFF
--- a/doc/result-set-builders.md
+++ b/doc/result-set-builders.md
@@ -138,10 +138,14 @@ The default implementation of this protocol is for these two functions to return
   java.sql.Date
   (read-column-by-label [^java.sql.Date v _]
     (.toLocalDate v))
+  (read-column-by-label [^java.sql.Date v _2 _3]
+    (.toLocalDate v))
   (read-column-by-index [^java.sql.Date v _2 _3]
     (.toLocalDate v))
   java.sql.Timestamp
   (read-column-by-label [^java.sql.Timestamp v _]
+    (.toInstant v))
+  (read-column-by-label [^java.sql.Timestamp v _2 _3]
     (.toInstant v))
   (read-column-by-index [^java.sql.Timestamp v _2 _3]
     (.toInstant v)))

--- a/doc/tips-and-tricks.md
+++ b/doc/tips-and-tricks.md
@@ -11,6 +11,8 @@ Columns declared with the `CLOB` or `BLOB` SQL types are typically rendered into
   java.sql.Clob
   (read-column-by-label [^java.sql.Clob v _]
     (with-open [rdr (.getCharacterStream v)] (slurp rdr)))
+  (read-column-by-label [^java.sql.Clob v _2 _3]
+    (with-open [rdr (.getCharacterStream v)] (slurp rdr)))
   (read-column-by-index [^java.sql.Clob v _2 _3]
     (with-open [rdr (.getCharacterStream v)] (slurp rdr))))
 ```
@@ -21,6 +23,8 @@ There is a helper in `next.jdbc.result-set` to make this easier -- `clob->string
 (extend-protocol rs/ReadableColumn
   java.sql.Clob
   (read-column-by-label [^java.sql.Clob v _]
+    (clob->string v))
+  (read-column-by-label [^java.sql.Clob v _2 _3_]
     (clob->string v))
   (read-column-by-index [^java.sql.Clob v _2 _3]
     (clob->string v)))
@@ -145,6 +149,7 @@ ResultSet protocol extension to read SQL arrays as Clojure vectors.
 (extend-protocol rs/ReadableColumn
   Array
   (read-column-by-label [^Array v _]    (vec (.getArray v)))
+  (read-column-by-label [^Array v _ _]  (vec (.getArray v)))
   (read-column-by-index [^Array v _ _]  (vec (.getArray v))))
 
 ```
@@ -271,6 +276,8 @@ Finally we extend `next.jdbc.prepare/SettableParameter` and `next.jdbc.result-se
 (extend-protocol rs/ReadableColumn
   org.postgresql.util.PGobject
   (read-column-by-label [^org.postgresql.util.PGobject v _]
+    (<-pgobject v))
+  (read-column-by-label [^org.postgresql.util.PGobject v _2 _3]
     (<-pgobject v))
   (read-column-by-index [^org.postgresql.util.PGobject v _2 _3]
     (<-pgobject v)))

--- a/src/next/jdbc/date_time.clj
+++ b/src/next/jdbc/date_time.clj
@@ -72,9 +72,11 @@
   (extend-protocol rs/ReadableColumn
     java.sql.Date
     (read-column-by-label [^java.sql.Date v _]     v)
+    (read-column-by-label [^java.sql.Date v _2 _3] v)
     (read-column-by-index [^java.sql.Date v _2 _3] v)
     java.sql.Timestamp
     (read-column-by-label [^java.sql.Timestamp v _]     (.toInstant v))
+    (read-column-by-label [^java.sql.Timestamp v _2 _3] (.toInstant v))
     (read-column-by-index [^java.sql.Timestamp v _2 _3] (.toInstant v))))
 
 (defn read-as-local
@@ -86,9 +88,11 @@
   (extend-protocol rs/ReadableColumn
     java.sql.Date
     (read-column-by-label [^java.sql.Date v _]     (.toLocalDate v))
+    (read-column-by-label [^java.sql.Date v _2 _3] (.toLocalDate v))
     (read-column-by-index [^java.sql.Date v _2 _3] (.toLocalDate v))
     java.sql.Timestamp
     (read-column-by-label [^java.sql.Timestamp v _]     (.toLocalDateTime v))
+    (read-column-by-label [^java.sql.Timestamp v _2 _3] (.toLocalDateTime v))
     (read-column-by-index [^java.sql.Timestamp v _2 _3] (.toLocalDateTime v))))
 
 (defn read-as-default
@@ -100,7 +104,9 @@
   (extend-protocol rs/ReadableColumn
     java.sql.Date
     (read-column-by-label [^java.sql.Date v _]     v)
+    (read-column-by-label [^java.sql.Date v _2 _3] v)
     (read-column-by-index [^java.sql.Date v _2 _3] v)
     java.sql.Timestamp
     (read-column-by-label [^java.sql.Timestamp v _]     v)
+    (read-column-by-label [^java.sql.Timestamp v _2 _3] v)
     (read-column-by-index [^java.sql.Timestamp v _2 _3] v)))


### PR DESCRIPTION
An attempt to address Issue #134 

Let's me do something like this.

```
(extend-protocol result-set/ReadableColumn
  Integer
  (read-column-by-label [x mrs name]
    (let [i (loop [i 0]
              (cond
                (> i (.getColumnCount mrs)) (throw (Exception. "unable to find column with name: " name))
                (= (.getColumnName mrs i) name) i
                :else (recur (inc i))))]
      (if (re-find #"(?i)bool" (.getColumnTypeName mrs i))
        (if (= 1 x) true false)
        x)))
  (read-column-by-index [x mrs i]
    (if (re-find #"(?i)bool" (.getColumnTypeName mrs i))
      (if (= 1 x) true false)
      x)))
```