### PR TITLE
Make next.jdbc.result-set/row-builder public

### DIFF
--- a/src/next/jdbc/result_set.clj
+++ b/src/next/jdbc/result_set.clj
@@ -422,7 +422,7 @@
   (datafiable-row [this connectable opts]
     "Produce a datafiable representation of a row from a `ResultSet`."))
 
-(defn- row-builder
+(defn row-builder
   "Given a `RowBuilder` -- a row materialization strategy -- produce a fully
   materialized row from it."
   [builder]


### PR DESCRIPTION
so users can use the `RowBuilder` objects returned by the other public functions in this namespace like `as-unqualified-kebab-maps` against a `ResultSet` object like one from a `PreparedStatement` as returned by `next.jdbc/prepare`