### PR TITLE
Make next.jdbc work with GraalVM 22 onwards

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:mvn/repos {"sonatype" {:url "https://oss.sonatype.org/content/repositories/snapshots/"}}
- :paths ["src"]
+ :paths ["src" "resources"]
  :deps {org.clojure/clojure {:mvn/version "1.10.3"}
         org.clojure/java.data {:mvn/version "1.0.86"}
 

--- a/resources/META-INF/native-image/io.github.seancorfield/next.jdbc/native-image.properties
+++ b/resources/META-INF/native-image/io.github.seancorfield/next.jdbc/native-image.properties
@@ -1,0 +1,2 @@
+Args=--initialize-at-build-time=clojure,next,camel_snake_kebab \
+     --initialize-at-build-time=java.sql.SQLException


### PR DESCRIPTION
Dear @seancorfield. The following configuration is the only requirement to make next.jdbc work with GraalVM. The configuration has already been tested by Eric Dallo and the automated pipeline https://github.com/clj-easy/graal-config

Although the configuration is already hosted in graal-config, the clj-easy organization recommends to distribute the configuration from the library artifact.  