### PR TITLE
Update log4j to 2.15.0 [CVE-2021-44228]

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -42,7 +42,7 @@
                       com.microsoft.sqlserver/mssql-jdbc {:mvn/version "8.2.1.jre8"}
                       ;; supplementary test stuff
                       ;; use log4j 2.x:
-                      org.apache.logging.log4j/log4j-api {:mvn/version "2.14.1"}
+                      org.apache.logging.log4j/log4j-api {:mvn/version "2.15.0"}
                       ;; bridge into log4j:
                       org.apache.logging.log4j/log4j-1.2-api {:mvn/version "2.14.1"}
                       org.apache.logging.log4j/log4j-jcl {:mvn/version "2.14.1"}


### PR DESCRIPTION
Update log4j to patch for vulnerability found where arbitrary code
execution can occur.

See: https://nvd.nist.gov/vuln/detail/CVE-2021-44228