### PR TITLE
insert-multi! hashmap support + batch mode

### DIFF
--- a/src/next/jdbc/specs.clj
+++ b/src/next/jdbc/specs.clj
@@ -180,16 +180,26 @@
                      :opts (s/? ::opts-map)))
 
 (s/fdef sql/insert-multi!
-        :args (s/and (s/cat :connectable ::connectable
-                            :table keyword?
-                            :cols (s/coll-of keyword?
-                                             :kind sequential?
-                                             :min-count 1)
-                            :rows (s/coll-of (s/coll-of any? :kind sequential?)
-                                             :kind sequential?)
-                            :opts (s/? ::opts-map))
-                     #(apply = (count (:cols %))
-                        (map count (:rows %)))))
+        :args
+        (s/or
+          :with-rows-and-columns
+          (s/and (s/cat :connectable ::connectable
+                        :table keyword?
+                        :cols (s/coll-of keyword?
+                                         :kind sequential?
+                                         :min-count 1)
+                        :rows (s/coll-of (s/coll-of any? :kind sequential?)
+                                         :kind sequential?)
+                        :opts (s/? ::opts-map))
+                 #(apply = (count (:cols %))
+                         (map count (:rows %))))
+          :with-hash-maps
+          (s/cat :connectable ::connectable
+                 :table keyword?
+                 :hash-maps (s/coll-of map?
+                                       :kind sequential?
+                                       :min-count 1)
+                 :opts (s/? ::opts-map))))
 
 (s/fdef sql/query
         :args (s/cat :connectable ::connectable

--- a/test/next/jdbc/sql/builder_test.clj
+++ b/test/next/jdbc/sql/builder_test.clj
@@ -146,11 +146,19 @@
                                {:id 9 :status 42 :opt nil}
                                {:table-fn sql-server :column-fn mysql})
            ["INSERT INTO [user] (`id`, `status`, `opt`) VALUES (?, ?, ?)" 9 42 nil])))
-  (testing "multi-row insert"
+  (testing "multi-row insert (normal mode)"
     (is (= (builder/for-insert-multi :user
                                      [:id :status]
                                      [[42 "hello"]
                                       [35 "world"]
                                       [64 "dollars"]]
                                      {:table-fn sql-server :column-fn mysql})
-           ["INSERT INTO [user] (`id`, `status`) VALUES (?, ?), (?, ?), (?, ?)" 42 "hello" 35 "world" 64 "dollars"]))))
+           ["INSERT INTO [user] (`id`, `status`) VALUES (?, ?), (?, ?), (?, ?)" 42 "hello" 35 "world" 64 "dollars"])))
+  (testing "multi-row insert (batch mode)"
+    (is (= (builder/for-insert-multi :user
+                                     [:id :status]
+                                     [[42 "hello"]
+                                      [35 "world"]
+                                      [64 "dollars"]]
+                                     {:table-fn sql-server :column-fn mysql :batch true})
+           ["INSERT INTO [user] (`id`, `status`) VALUES (?, ?)" [42 "hello"] [35 "world"] [64 "dollars"]]))))

--- a/test/next/jdbc/sql_test.clj
+++ b/test/next/jdbc/sql_test.clj
@@ -152,6 +152,36 @@
       (is (= {:next.jdbc/update-count 2}
              (sql/delete! (ds) :fruit ["id > ?" 4])))
       (is (= 4 (count (sql/query (ds) ["select * from fruit"])))))
+    (testing "multiple insert/delete with maps"
+      (is (= (cond (derby?)
+                   [nil] ; WTF Apache Derby?
+                   (mssql?)
+                   [14M]
+                   (sqlite?)
+                   [14]
+                   :else
+                   [12 13 14])
+             (mapv new-key
+                   (sql/insert-multi! (ds) :fruit
+                                      [{:name       "Kiwi"
+                                        :appearance "green & fuzzy"
+                                        :cost       100
+                                        :grade      99.9}
+                                       {:name       "Grape"
+                                        :appearance "black"
+                                        :cost       10
+                                        :grade      50}
+                                       {:name       "Lemon"
+                                        :appearance "yellow"
+                                        :cost       20
+                                        :grade      9.9}]))))
+      (is (= 7 (count (sql/query (ds) ["select * from fruit"]))))
+      (is (= {:next.jdbc/update-count 1}
+             (sql/delete! (ds) :fruit {:id 12})))
+      (is (= 6 (count (sql/query (ds) ["select * from fruit"]))))
+      (is (= {:next.jdbc/update-count 2}
+             (sql/delete! (ds) :fruit ["id > ?" 10])))
+      (is (= 4 (count (sql/query (ds) ["select * from fruit"])))))
     (testing "empty insert-multi!" ; per #44
       (is (= [] (sql/insert-multi! (ds) :fruit
                                    [:name :appearance :cost :grade]


### PR DESCRIPTION
Updates `insert-multi!` to support taking hash maps in addition to `rows` and `cols`. Also introduces a `:batch` flag which will call `execute-batch!` instead of the standard `execute!`

Note: I didn't have all of the fixture databases (I dev'd against embedded postgres) available locally and it looks like CI doesn't run on PRs for first time contributors so it may be worth testing this locally before merging it.