### PR TITLE
Make Transactable extensible via metadata

### DIFF
--- a/src/next/jdbc/protocols.clj
+++ b/src/next/jdbc/protocols.clj
@@ -54,7 +54,7 @@
   (prepare ^java.sql.PreparedStatement [this sql-params opts]
     "Produce a new `java.sql.PreparedStatement` for use with `with-open`."))
 
-(defprotocol Transactable
+(defprotocol Transactable :extend-via-metadata true
   "Protocol for running SQL operations in a transaction.
 
   Implementations are provided for `Connection`, `DataSource`, and `Object`


### PR DESCRIPTION
This is the only missing piece for a metadata-based no-op Component, which I want for tests that must not hit a database, yet still realistically hit the next.jdbc code as used throughout my codebase.

In specific terms, I have a scenario that looks approximately like this:

```clj
(def ^:dynamic *emitted-sql*
  nil)

(def ^:dynamic *sql-results*
  nil)

(defn make-test-system []
  (let [sql-mock-fn (fn [_ q]
                      (some-> *emitted-sql* (swap! conj q))
                      (some-> *sql-results* deref (get q)))
        sql (with-meta {:pool (with-meta {}
                                {`jdbc.protocols/get-datasource (constantly (with-meta {}
                                                                              {`jdbc.protocols/-transact (constantly nil)}))})}
              ;; implementations of a custom application-level protocol (not the next.jdbc protocols)
              {`sql/execute!     sql-mock-fn
               `sql/execute-one! sql-mock-fn})]
    {:sql sql
     :another-component (with-meta {:sql sql}
                          `my-app/do-it (fn [this]
                                          (next.jdbc/with-transaction (-> this :sql :pool)
                                            ,,,)))}))

(deftest works ;; sample usage
  (binding [*emitted-sql* (atom [])
            *sql-results* (atom {})]
    (let [{:keys [another-component] (make-test-system)}]
      (my-app/do-it another-component)
      (is (= *emitted-sql* ,,,)))))
```

In other words, I want to have a simple app-specific protocol for sql interactions, while still being able to use `with-transaction`. So bespoke implementations have to implement not only Sourceable, but also Transactable.

(note that I cannot create an application-specific protocol _for a macro_ - macros aren't protocol-able)

I hope you appreciate the highly realistic example. IIRC you don't like to add `:extend-via-metadata true` where not needed.

Cheers - V