### PR TITLE
Always call setReadOnly when opening a transaction

### DIFF
--- a/src/next/jdbc/transaction.clj
+++ b/src/next/jdbc/transaction.clj
@@ -65,8 +65,8 @@
     (io!
      (when isolation
        (.setTransactionIsolation con (isolation isolation-levels)))
-     (when read-only
-       (.setReadOnly con true))
+     (when (contains? opts :read-only)
+       (.setReadOnly con (boolean read-only)))
      (.setAutoCommit con false)
      (try
        (let [result (f con)]
@@ -107,7 +107,7 @@
            (try
              (.setTransactionIsolation con old-isolation)
              (catch Exception _)))
-         (when read-only
+         (when (contains? opts :read-only)
            (try
              (.setReadOnly con old-readonly)
              (catch Exception _))))))))

--- a/test/next/jdbc/test_fixtures.clj
+++ b/test/next/jdbc/test_fixtures.clj
@@ -90,6 +90,8 @@
 
 (defn stored-proc? [] (not (#{"derby" "h2" "h2:mem" "sqlite"} (:dbtype @test-db-spec))))
 
+(defn can-set-read-only? [] (not (#{"h2" "h2:mem" "sqlite"} (:dbtype @test-db-spec))))
+
 (defn column [k]
   (let [n (namespace k)]
     (keyword (when n (cond (postgres?) (str/lower-case n)


### PR DESCRIPTION
Hey Sean :wave: 

This ensures that if the connection has been set to read-only and the user supplies `{:read-only false}` as tx opts, we call `(.setReadOnly conn false)` when we open the transaction, and reset it afterwards.

I did wonder whether it was intentional _not_ to make a read-only connection read-write - not something I've come across personally but maybe it'd be considered 'safer'?

Cheers,

James