### PR TITLE
fix #229

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Only accretive/fixative changes will be made from now on.
 
 * 1.3.next in progress
+  * Fix [#229](https://github.com/seancorfield/next-jdbc/issues/229) by adding `next.jdbc.connect/uri->db-spec` which converts a URI string to a db-spec hash map; in addition, if `DriverManager/getConnection` fails, it assumes it was passed a URI instead of a JDBC URL, and retries after calling that function and then recreating the JDBC URL (which should have the effect of moving the embedded user/password credentials into the properties structure instead of the URL).
   * Address [#228](https://github.com/seancorfield/next-jdbc/issues/228) by adding `PreparedStatement` caveat to the Oracle **Tips & Tricks** section.
 
 * 1.3.834 -- 2022-09-23

--- a/test/next/jdbc/connection_string_test.clj
+++ b/test/next/jdbc/connection_string_test.clj
@@ -1,0 +1,41 @@
+;; copyright (c) 2019-2021 Sean Corfield, all rights reserved
+
+(ns next.jdbc.connection-string-test
+  "Tests for the main hash map spec to JDBC URL logic and the get-datasource
+  and get-connection protocol implementations.
+
+  At some point, the datasource/connection tests should probably be extended
+  to accept EDN specs from an external source (environment variables?)."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [next.jdbc.connection :as c]
+            [next.jdbc.protocols :as p]
+            [next.jdbc.specs :as specs]
+            [next.jdbc.test-fixtures :refer [with-test-db db]]))
+
+(set! *warn-on-reflection* true)
+
+(use-fixtures :once with-test-db)
+
+(specs/instrument)
+
+(deftest test-uri-strings
+  (testing "datasource via String"
+    (let [db-spec (db)
+          db-spec (if (= "embedded-postgres" (:dbtype db-spec))
+                    (assoc db-spec :dbtype "postgresql")
+                    db-spec)
+          [url etc] (#'c/spec->url+etc db-spec)
+          {:keys [user password]} etc
+          etc (dissoc etc :user :password)
+          uri (-> url
+                  ;; strip jdbc: prefix for fun
+                  (str/replace #"^jdbc:" "")
+                  (str/replace #";" "?") ; for SQL Server tests
+                  (str/replace #":sqlserver" "") ; for SQL Server tests
+                  (cond-> (and user password)
+                    (str/replace #"://" (str "://" user ":" password "@"))))
+          ds (p/get-datasource (assoc etc :jdbcUrl uri))]
+      (when (and user password)
+        (with-open [con (p/get-connection ds {})]
+          (is (instance? java.sql.Connection con)))))))


### PR DESCRIPTION
This makes it easier to migrate from `clojure.java.jdbc`, which supported this format. Adds `next.jdbc.connect/uri->db-spec` and will automatically retry `getConnection` calls that fail, assuming they were passed a URI instead of a JDBC URL.

Fixes #229 