### PR TITLE
Doc: Fix incorrect parentheses in doc for find-by-keys

### DIFF
--- a/doc/friendly-sql-functions.md
+++ b/doc/friendly-sql-functions.md
@@ -169,7 +169,7 @@ The default behavior is to return all the columns in each row. You can specify a
 * a pair consisting of a string and a keyword, representing a SQL expression and an alias (`:column-fn` will be applied to the alias, if provided).
 
 ```clojure
-(sql/find-by-keys ds :address {:name "Stella"} {:columns [[:email :address]]})
+(sql/find-by-keys ds :address {:name "Stella"} {:columns [:email :address]})
 ;; equivalent to
 (jdbc/execute! ds ["SELECT email AS address FROM address WHERE name = ?"
                    "Stella"])


### PR DESCRIPTION
I just tried the `find-by-keys` function for the first time following the docs:
```clojure
(sql/find-by-keys db/ds :messages {:email "joe@bloggs.com"} {:columns [[:id]]})
```
I got this error:
```clojure
Execution error (NullPointerException) at next.jdbc.sql.builder/safe-name (builder.clj:27).
Cannot invoke "clojure.lang.Named.getName()" because "x" is null
```
I changed `{:columns [[:id]]}` to `{:columns [:id]}` and it worked and returned me the results I needed.  My observed behaviour is what I'd expect anyway, so I think it's just a typo.