### PR TITLE
Adding DuckDB support

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -39,6 +39,7 @@
                       io.zonky.test.postgres/embedded-postgres-binaries-windows-amd64 {:mvn/version "16.1.1"}
                       org.xerial/sqlite-jdbc {:mvn/version "3.44.1.0"}
                       com.microsoft.sqlserver/mssql-jdbc {:mvn/version "12.4.1.jre11"}
+                      org.duckdb/duckdb_jdbc {:mvn/version "0.10.0"}
                       ;; use log4j2 to reduce log noise during testing:
                       org.apache.logging.log4j/log4j-api {:mvn/version "2.22.0"}
                       ;; bridge everything into log4j:

--- a/test/next/jdbc/connection_test.clj
+++ b/test/next/jdbc/connection_test.clj
@@ -125,7 +125,7 @@
                                :useSSL true :user "dba"}))))))
 
 ;; these are the 'local' databases that we can always test against
-(def test-db-type ["derby" "h2" "h2:mem" "hsqldb" "sqlite"])
+(def test-db-type ["derby" "h2" "h2:mem" "hsqldb" "sqlite" "duckdb"])
 
 (def test-dbs
   (for [db test-db-type]


### PR DESCRIPTION
This is a WIP branch to improve `duckdb` support in `next.jdbc`.