### PR TITLE
Fix documentation of next.jdbc/execute-batch!

### DIFF
--- a/doc/friendly-sql-functions.md
+++ b/doc/friendly-sql-functions.md
@@ -117,8 +117,8 @@ will use `execute-batch!` under the hood, instead of `execute!`, as follows:
   {:batch true})
 ;; equivalent to
 (jdbc/execute-batch! ds
-                     ["INSERT INTO address (name,email) VALUES (?,?)"
-                      ["Stella" "stella@artois.beer"]
+                     "INSERT INTO address (name,email) VALUES (?,?)"
+                     [["Stella" "stella@artois.beer"]
                       ["Waldo" "waldo@lagunitas.beer"]
                       ["Aunt Sally" "sour@lagunitas.beer"]]
                      {:return-keys true :return-generated-keys true})
@@ -131,8 +131,8 @@ will use `execute-batch!` under the hood, instead of `execute!`, as follows:
   {:batch true})
 ;; equivalent to
 (jdbc/execute-batch! ds
-                     ["INSERT INTO address (name,email) VALUES (?,?)"
-                      ["Stella" "stella@artois.beer"]
+                     "INSERT INTO address (name,email) VALUES (?,?)"
+                     [["Stella" "stella@artois.beer"]
                       ["Waldo" "waldo@lagunitas.beer"]
                       ["Aunt Sally" "sour@lagunitas.beer"]]
                      {:return-keys true :return-generated-keys true})


### PR DESCRIPTION
Searching for documentation for `next.jdbc/execute-batch!`, I tried to
execute the "equivalent to" examples of the `next.jdbc.sql/insert-multi!`
documentation, but encountered:
```
java.lang.ClassCastException: class clojure.lang.PersistentArrayMap cannot be cast to class java.sql.PreparedStatement
```

Fixes: 3ed1f4b99c975b556327d1abb9b387db8a6d93a6
